### PR TITLE
Avoid creating an existing project

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ Swagger interface http://localhost:8081/docs
 
 # Version history
 
-## Current: 2.6.2
+## Current: 2.7
 
 ## History
+- 2.7
+  - Avoid creating an existing project. Raise an error doing so.
+  - Catch error when the app restart and a user is still connected (SignatureError with new key)
 - 2.6.2
   - Fix mongo alias naming for id
   - Fix Object not subscriptable error

--- a/app/api.py
+++ b/app/api.py
@@ -22,7 +22,7 @@ Eaidashboard is a simple api and front to monitor test activities.
 """
 app = FastAPI(title="Eaidashboard",
               description=description,
-              version="2.6.2",
+              version="2.7",
               license_info={
                   "name": "GNU GPL v3",
                   "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"

--- a/app/app_exception.py
+++ b/app/app_exception.py
@@ -5,6 +5,9 @@ class InsertionError(Exception):
     pass
 
 
+class DuplicateProject(Exception):
+    pass
+
 class ProjectNotRegistered(Exception):
     pass
 

--- a/app/database/authorization.py
+++ b/app/database/authorization.py
@@ -36,24 +36,27 @@ def authorize_user(security_scopes: SecurityScopes,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": authenticate_value},
     )
-    # Authorize method
-    # Token contains the username
-    email = token_user(token)
-    if email is None:
-        raise credentials_exception
+    try:
+        # Authorize method
+        # Token contains the username
+        email = token_user(token)
+        if email is None:
+            raise credentials_exception
 
-    # Check user in db
-    user = get_user(email)
-    if user is None:
-        raise credentials_exception
+        # Check user in db
+        user = get_user(email)
+        if user is None:
+            raise credentials_exception
 
-    # Check token validity
-    if get_token_date(user["username"]) is None:
-        raise credentials_exception
+        # Check token validity
+        if get_token_date(user["username"]) is None:
+            raise credentials_exception
 
-    # Check user right
-    token_scopes = token_scope(token)
-    token_data = TokenData(scopes=token_scopes, email=email)
+        # Check user right
+        token_scopes = token_scope(token)
+        token_data = TokenData(scopes=token_scopes, email=email)
+    except jwt.InvalidSignatureError:
+        raise credentials_exception
     if (all(scope not in security_scopes.scopes for scope in token_data.scopes)
             and security_scopes.scopes):
         raise credentials_exception

--- a/app/utils/project_alias.py
+++ b/app/utils/project_alias.py
@@ -37,5 +37,5 @@ def provide(project_name: str):
 
 
 def contains(project_name) -> bool:
-    return (project_name in list(PROJECT_ALIAS.keys())
+    return (project_name.casefold() in list(PROJECT_ALIAS.keys())
             or _compute_alias(project_name) in list(PROJECT_ALIAS.keys()))


### PR DESCRIPTION
- Avoid creating an existing project. Raise an error doing so.
- Catch error when the app restart and a user is still connected (SignatureError with new key)